### PR TITLE
Statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .credentials
 export.qif
 export
-db.pyc
+*.pyc
 2013.07.06-2013.07.24.qif
 transactions.db
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -24,20 +24,28 @@ extend this section with detailed steps for your platform.
 ## Usage
 
 Simply start `export.py` in your shell of choice (cmd.exe, bash, zsh etc).
-You will be prompted for your username & password. **THESE details will not be 
+You will be prompted for your username & password. **THESE details will not be
 used for anything but logging into the 28degrees' website.**
 
 Then the tool will go through several stages, printing some supplementary information
 into console. Do not worry about that unless these are actually error
 messages.
 
-When it's done, you should see file that looks like `YYYY.MM.DD-YYYY.MM.DD.qif` under 
+When it's done, you should see file that looks like `YYYY.MM.DD-YYYY.MM.DD.qif` under
 the 'export' folder, where YYYY.DD.MM are the dates for the first and last transactions
-in the exported dataset. It will also create a transactions.db file (sqlite database) but 
-you can ignore this one - we simply need it to keep track of transactios that have already
-been recorded. 
+in the exported dataset. It will also create a transactions.db file (sqlite database) but
+you can ignore this one - we simply need it to keep track of transactions that have already
+been recorded.
 
 If you want to re-start the process, just delete (or re-name, which is safer) transactions.db file.
+
+Should you want a copy of all the statements on the website, add the `--statements` argument
+when calling `export.py` and a PDF copy of each available statement will be saved after the
+transactions process is complete. Statements will be saved as `28 Degrees Statement YYYY-MM-DD.pdf`
+to the 'export' folder. After `export.py` has finished running you can safely copy the
+files from the 'export' folder. However if you *move* the files subsequent runs of
+`export.py` will result in the downloading of each statement again as the check to download
+missing statements is based on the existence of PDFs in the 'export' folder.
 
 ## Errors / support
 


### PR DESCRIPTION
Thank you for creating this project as it fills, I think, a large gap in their website. I'm not much of a python'er but I wanted to grab all the statement PDFs from the site at the same time, just in case as it is their official record. I tried to be as close to the existing style as possible. Essentially all I changed was:

* Modified .gitignore to ignore all pyc
* Added `--statements` argument with a default to off
* Added `open_statements_page` function to grab HTML of the statements page
* On the statements page all statements have a class of `s_downloads` in their a tag so grab them
* Loop through all of them and save any missing ones to export as `28 Degrees Statement YYYY-MM-DD.pdf`
* Updated README.md to describe to users the new feature

Sorry if I'm doing anything wrong, this is my first time contributing to anything so this is all quite new to me. I hope this feature is of some use to you and everyone else!